### PR TITLE
upgrade Bullseye, SimpleExec, and Minver

### DIFF
--- a/build/build.csproj
+++ b/build/build.csproj
@@ -6,9 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Bullseye" Version="3.0.0" />
+    <PackageReference Include="Bullseye" Version="3.3.0" />
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.4.1" />
-    <PackageReference Include="SimpleExec" Version="6.1.0" />
+    <PackageReference Include="SimpleExec" Version="6.2.0" />
   </ItemGroup>
   
 </Project>

--- a/src/OidcCli.csproj
+++ b/src/OidcCli.csproj
@@ -24,10 +24,7 @@
 
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.2.0" />
 
-    <PackageReference Include="minver" Version="2.0.0">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
+    <PackageReference Include="MinVer" Version="2.2.0" PrivateAssets="All" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
 


### PR DESCRIPTION
- Bullseye: 3.0.0 → 3.3.0
- SimpleExec: 6.1.0 → 6.2.0
- Minver: 2.0.0 → 2.2.0